### PR TITLE
Updates for v2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ config.ini
 tests/img_test.jpg
 venv/
 logs/
+privileges/privileges.csv

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 permanent_media/
 temporary_media/
 temporary_images/
+privileges.csv
 aliases.csv
 config.ini
 tests/img_test.jpg

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ __pycache__/
 permanent_media/
 temporary_media/
 temporary_images/
-privileges.csv
 aliases.csv
 config.ini
 tests/img_test.jpg

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,8 @@ __pycache__/
 permanent_media/
 temporary_media/
 temporary_images/
-privileges.csv
 aliases.csv
 config.ini
 tests/img_test.jpg
 venv/
 logs/
-privileges/privileges.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: python
 python:
   - "3.6"
-  - "3.7"
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y libopus
-  - sudo apt-get install -y opus-tools
 install:
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python:
   - "3.6"
+dist: trusty
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y libopus0
 install:
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - "3.6"
   - "3.7"
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y libopus
+  - sudo apt-get install -y opus-tools
 install:
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
-python: 3.6
+python:
+  - "3.6"
+  - "3.7"
 install:
-   - pip install -r requirements.txt
+  - pip install -r requirements.txt
 
 # Run Tests
 # Built-in Plugin Tests
 script:
-    - python tests/test_config.py
-    - python tests/test_images.py
-    - python tests/test_plugins.py
+  - python tests/test_config.py
+  - python tests/test_images.py
+  - python tests/test_plugins.py

--- a/JJMumbleBot.py
+++ b/JJMumbleBot.py
@@ -589,7 +589,7 @@ class JJMumbleBot:
 
     def exit(self):
         GM.gui.quick_gui(
-            f"{utils.get_bot_name()} was manually disconnected.",
+            f"{utils.get_bot_name()} is being shutdown.",
             text_type='header',
             box_align='left')
         for plugin in self.bot_plugins.values():

--- a/JJMumbleBot.py
+++ b/JJMumbleBot.py
@@ -16,6 +16,8 @@ from helpers.cmd_history import CMDQueue
 from bs4 import BeautifulSoup
 import threading
 import copy
+from helpers.global_access import RemoteTextMessage
+from helpers.web_handler import init_web, stop_web
 
 
 class JJMumbleBot:
@@ -25,6 +27,8 @@ class JJMumbleBot:
     bot_status = "Offline"
     # Dictionary of registered bot plugins.
     bot_plugins = {}
+    # Web thread.
+    web_thr = None
     # Command history.
     cmd_history = None
     # Runtime parameters.
@@ -35,6 +39,8 @@ class JJMumbleBot:
 
     def __init__(self):
         print("JJ Mumble Bot Initializing...")
+        # Core access.
+        GM.jjmumblebot = self
         # Initialize configs.
         GM.cfg.read(utils.get_config_dir())
         # Initialize up-time tracker.
@@ -140,6 +146,12 @@ class JJMumbleBot:
         self.plugin_callback_test()
         GM.logger.info("Plugin callback test successful.")
         print("JJ Mumble Bot initialized!\n")
+        # Initialize the web interface.
+        if GM.cfg.getboolean('Connection_Settings', 'EnableWebInterface'):
+            self.web_thr = threading.Thread(target=init_web)
+            self.web_thr.start()
+            reg_print("JJMumbleBot Web Service was initialized.")
+            GM.logger.info("JJMumbleBot Web Service was initialized.")
         # Join the server after all initialization is complete.
         self.join_server()
         GM.logger.info("JJ Mumble Bot has fully initialized and joined the server.")
@@ -510,6 +522,71 @@ class JJMumbleBot:
             thr = threading.Thread(target=plugin.process_command, args=(command_text,))
             thr.start()
 
+    def remote_command(self, message):
+        if message[0] == self.cmd_token:
+            GM.logger.info(f"Commands Received: [RemoteWebCall] -> {message}]")
+            self.live_plugin_check()
+
+            text = RemoteTextMessage(channel_id=GM.mumble.users.myself['channel_id'], session=GM.mumble.users.myself['session'], message=message, actor=GM.mumble.users.myself['session'])
+            # example input: !version ; !about ; !yt twice ; !p ; !status
+            all_commands = [msg.strip() for msg in message.split(';')]
+            # example output: ["!version", "!about", "!yt twice", "!p", "!status"]
+
+            # add to command history
+            cmd_list = [self.cmd_history.insert(cmd) for cmd in all_commands]
+
+            if len(all_commands) > self.multi_cmd_limit:
+                reg_print(
+                    f"The multi-command limit was reached! The multi-command limit is {self.multi_cmd_limit} commands per line.")
+                GM.logger.warning(
+                    f"The multi-command limit was reached! The multi-command limit is {self.multi_cmd_limit} commands per line.")
+                return
+
+            # Iterate through all commands provided and generate commands.
+            for i, item in enumerate(all_commands):
+                # Generate command with parameters
+                #new_text = copy.deepcopy(text)
+                new_text = text
+                new_text.message = item
+                new_command = None
+                try:
+                    new_command = Command(item[1:].split()[0], new_text)
+                except IndexError:
+                    continue
+
+                if new_command.command in aliases.aliases:
+                    alias_commands = [msg.strip() for msg in aliases.aliases[new_command.command].split('|')]
+                    if len(alias_commands) > self.multi_cmd_limit:
+                        reg_print(
+                            f"The multi-command limit was reached! The multi-command limit is {self.multi_cmd_limit} commands per line.")
+                        GM.logger.warning(
+                            f"The multi-command limit was reached! The multi-command limit is {self.multi_cmd_limit} commands per line.")
+                        return
+                    for x, sub_item in enumerate(alias_commands):
+                        #sub_text = copy.deepcopy(text)
+                        sub_text = text
+                        if len(item[1:].split()) > 1:
+                            sub_text.message = f"{sub_item} {item[1:].split(' ', 1)[1]}"
+                        else:
+                            sub_text.message = sub_item
+
+                        sub_command = None
+                        try:
+                            sub_command = Command(sub_item[1:].split()[0], sub_text)
+                        except IndexError:
+                            continue
+
+                        self.command_queue.insert(sub_command)
+                else:
+                    # Insert command into the command queue
+                    self.command_queue.insert(new_command)
+
+            # Process commands if the queue is not empty
+            while not self.command_queue.is_empty():
+                # Process commands in the queue
+                self.process_command_queue(self.command_queue.pop())
+                time.sleep(self.tick_rate)
+
     def exit(self):
         GM.gui.quick_gui(
             f"{utils.get_bot_name()} was manually disconnected.",
@@ -519,6 +596,11 @@ class JJMumbleBot:
             plugin.quit()
         utils.clear_directory(utils.get_temporary_img_dir())
         reg_print("Cleared temporary directories.")
+        if self.web_thr:
+            stop_web()
+            self.web_thr.join()
+            reg_print("JJMumbleBot Web Interface was disconnected.")
+            GM.logger.info("JJMumbleBot Web Interface was disconnected.")
         self.exit_flag = True
 
     def loop(self):

--- a/helpers/global_access.py
+++ b/helpers/global_access.py
@@ -1,11 +1,16 @@
 import configparser
 import time
 import datetime
+from pymumble.pymumble_py3.messages import Cmd as PyMessages
+from pymumble.pymumble_py3.constants import *
 
 
 class GlobalMods:
-    # JJMumbleBot Version
-    version = "v2.0.1"
+    # JJMumbleBot data
+    version = "v2.1.0"
+    jjmumblebot = None
+    # Web interface
+    web_server = None
     # Mumble instance
     mumble = None
     # Config Access
@@ -27,6 +32,18 @@ class GlobalMods:
     minutes = 0
     hours = 0
     days = 0
+
+
+class RemoteTextMessage(PyMessages):
+    def __init__(self, session, channel_id, message, actor):
+        PyMessages.__init__(self)
+
+        self.cmd = PYMUMBLE_CMD_TEXTMESSAGE
+        self.actor = actor
+        self.parameters = {"session": session,
+                           "channel_id": channel_id,
+                           "message": message,
+                           "actor": actor}
 
 
 def debug_print(msg):

--- a/helpers/templates/index.html
+++ b/helpers/templates/index.html
@@ -1,0 +1,54 @@
+<html>
+  <head>
+     <title>JJMumbleBot Web Interface Form</title>
+     <link rel="stylesheet" media="screen" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css">
+     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  </head>
+  <body>
+
+    <div class="container"><br>
+      <center>
+        <h2>JJMumbleBot Web Interface</h2>
+      </center>
+    </div>
+
+    <div class=container"><br>
+    <div class="row align-items-center justify-content-center">
+    <div class="col-md-4">
+      <form  action="" method="post" role="form">
+        {{ form.csrf }}
+        <div class="form-group">
+          <label for="commandField">Command:</label>
+          <input type="text" class="form-control" id="commandField" name="commandField" placeholder="Please enter a command...">
+	    <br>
+	</div>
+        <br>
+        <center>
+          <button type="submit" class="btn btn-success">Submit</button>
+        </center>
+      </form>
+      <br>
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+        {% for message in messages %}
+            {% if "Error" not in message[1]: %}
+                <div class="alert alert-info">
+                <strong>Success! </strong> {{ message[1] }}
+                </div>
+            {% endif %}
+            {% if "Error" in message[1]: %}
+                <div class="alert alert-danger">
+                <strong>Error: </strong> {{ message[1] }}
+                </div>
+            {% endif %}
+        {% endfor %}
+            {% endif %}
+        {% endwith %}
+    </div>
+    <br>
+    </div>
+    </div>
+  </body>
+</html>

--- a/helpers/web_handler.py
+++ b/helpers/web_handler.py
@@ -1,0 +1,37 @@
+from flask import Flask, render_template, flash, request, redirect
+from wtforms import Form, validators, StringField
+from helpers.global_access import GlobalMods as GM
+from cheroot.wsgi import Server as wsgiserver, PathInfoDispatcher
+from os import urandom
+
+web_app = Flask(__name__)
+web_app.config['SECRET_KEY'] = urandom(16)
+
+
+class CommandForm(Form):
+    commandField = StringField('Command: ', validators=[validators.DataRequired()])
+
+
+@web_app.route("/", methods=['GET', 'POST'])
+def main():
+    form = CommandForm(request.form)
+    if request.method == 'POST':
+        command = request.form['commandField']
+        if form.validate():
+            GM.jjmumblebot.remote_command(command)
+            flash(f'Command Sent: {command}')
+            return redirect('/')
+        else:
+            flash("Error: A command is required!")
+    return render_template('index.html', form=form)
+
+
+def init_web():
+    d = PathInfoDispatcher({'/': web_app})
+    GM.web_server = wsgiserver((GM.cfg['Web_Interface']['WebIP'], int(GM.cfg['Web_Interface']['WebPort'])), d)
+    GM.web_server.start()
+
+
+def stop_web():
+    if GM.web_server is not None:
+        GM.web_server.stop()

--- a/helpers/web_handler.py
+++ b/helpers/web_handler.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, flash, request, redirect
 from wtforms import Form, validators, StringField
 from helpers.global_access import GlobalMods as GM
-from cheroot.wsgi import Server as wsgiserver, PathInfoDispatcher
+from cheroot.wsgi import Server as WsgiServer, PathInfoDispatcher
 from os import urandom
 
 web_app = Flask(__name__)
@@ -28,7 +28,7 @@ def main():
 
 def init_web():
     d = PathInfoDispatcher({'/': web_app})
-    GM.web_server = wsgiserver((GM.cfg['Web_Interface']['WebIP'], int(GM.cfg['Web_Interface']['WebPort'])), d)
+    GM.web_server = WsgiServer((GM.cfg['Web_Interface']['WebIP'], int(GM.cfg['Web_Interface']['WebPort'])), d)
     GM.web_server.start()
 
 

--- a/plugins/youtube/youtube.py
+++ b/plugins/youtube/youtube.py
@@ -27,7 +27,7 @@ class Plugin(PluginBase):
                         <b>!queue/!q</b>: Displays the youtube queue.<br>\
                         <b>!song</b>: Shows currently playing track.<br>\
                         <b>!clear</b>: Clears the current youtube queue.<br>"
-    plugin_version = "2.0.0"
+    plugin_version = "2.1.0"
     priv_path = "youtube/youtube_privileges.csv"
 
     sound_board_plugin = None

--- a/plugins/youtube/youtube.py
+++ b/plugins/youtube/youtube.py
@@ -227,7 +227,6 @@ class Plugin(PluginBase):
 
             YH.all_searches = YM.get_search_results(search_term)
             search_results = YM.get_choices(YH.all_searches)
-
             GM.gui.quick_gui(
                 f"{search_results}\nWhich one would you like to play?",
                 text_type='header',

--- a/plugins/youtube/youtube_helper.py
+++ b/plugins/youtube/youtube_helper.py
@@ -290,7 +290,7 @@ def get_choices(all_searches):
     list_urls = f"<font color='{GM.cfg['PGUI_Settings']['HeaderTextColor']}'>Search Results:</font><br>"
     for i in range(10):
         completed_url = "https://www.youtube.com" + all_searches[i]['href']
-        list_urls = f"<font color='{GM.cfg['PGUI_Settings']['IndexTextColor']}'>[{i}]</font> - <a href='{completed_url}'>[{all_searches[i]['title']}]</a><br>"
+        list_urls += f"<font color='{GM.cfg['PGUI_Settings']['IndexTextColor']}'>[{i}]</font> - <a href='{completed_url}'>[{all_searches[i]['title']}]</a><br>"
     return list_urls
 
 

--- a/privileges/privileges.csv
+++ b/privileges/privileges.csv
@@ -1,1 +1,2 @@
 user,level
+DuckBot,5

--- a/privileges/privileges.csv
+++ b/privileges/privileges.csv
@@ -1,2 +1,1 @@
 user,level
-DuckBot,5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+wtforms==2.2.1
+cheroot==6.5.4
+flask==1.0.2
 opuslib==3.0.1
 youtube_dl==2019.4.24
 requests==2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-wtforms==2.2.1
-cheroot==6.5.4
-flask==1.0.2
 opuslib==3.0.1
 youtube_dl==2019.4.24
 requests==2.21.0
@@ -8,3 +5,6 @@ Pillow==6.0.0
 beautifulsoup4==4.7.1
 protobuf==3.7.1
 configparser==3.7.4
+wtforms==2.2.1
+cheroot==6.5.4
+flask==1.0.2

--- a/templates/sample_config.ini
+++ b/templates/sample_config.ini
@@ -7,6 +7,14 @@ ServerPort = PORT_NUMBER
 UserCertification = CERT_FILE_PATH
 ; The default channel the bot joins when it connects to the server
 DefaultChannel = DEFAULT_CHANNEL_NAME
+; Enable the bot's web interface (accessible through 127.0.0.1:8080)
+EnableWebInterface = true
+
+[Web_Interface]
+; Web Interface IP
+WebIP = 0.0.0.0
+; Web Interface Port
+WebPort = 8080
 
 [Media_Directories]
 ; Temporary image directory to store youtube thumbnails and other image content. This directory is cleared when the bot exits

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ class Tests(unittest.TestCase):
 
     def test_version(self):
         bot_version = GM.version
-        self.assertEqual(bot_version, "v2.0.1")
+        self.assertEqual(bot_version, "v2.1.0")
 
     def test_server_ip(self):
         server_ip = GM.cfg['Connection_Settings']['ServerIP']

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -36,7 +36,7 @@ class Tests(unittest.TestCase):
 
     def test_version_youtube(self):
         cur_plugin = self.bot_plugins.get('youtube')
-        self.assertEqual(cur_plugin.get_plugin_version(), "2.0.0")
+        self.assertEqual(cur_plugin.get_plugin_version(), "2.1.0")
 
     def test_version_sound_board(self):
         cur_plugin = self.bot_plugins.get('sound_board')


### PR DESCRIPTION
## Major Updates
⚠️ Existing users will have to update their config.ini files with the new properties from the sample_config.ini template file under the templates directory.

- Added a basic web interface to remotely send commands to the bot. This is especially useful when you need to send commands to the bot without logging into the mumble server.
- Make sure to add your bot to your privileges.csv file because the remote commands are executed as the bot user (not a client user). (The wiki's quick start guide has been updated for this)
![image](https://user-images.githubusercontent.com/20238115/56931857-78cc8080-6aaf-11e9-92d9-294addd7eb57.png)


## Bug Fixes
- Fixed !yt command not properly showing the full search results.

## New Dependencies For Web Interface
- cheroot
- flask
- wtforms

## Other Updates
- Updated bot version and youtube plugin to v2.1.0
- Updated gitignore, unit tests, and travis CI files
- Updated requirements file with new dependencies
- Changed the bot shut down message
- Updated README