### PR TITLE
Fix launch issue for new users when no internal database exists

### DIFF
--- a/JJMumbleBot/cfg/templates/config_template.ini
+++ b/JJMumbleBot/cfg/templates/config_template.ini
@@ -49,6 +49,8 @@ SafeModePlugins = ["core_commands", "bot_commands"]
 AllowedRootChannelsForTempChannels = ["Root"]
 
 [Main Settings]
+; Enable or disable automatic internal database backups
+EnableDatabaseBackup = True
 ; Enable or disable stereo sound output
 UseStereoOutput = True
 ; The execution tick rate of commands in the command queue [Must be an integer/float]

--- a/JJMumbleBot/core/bot_service.py
+++ b/JJMumbleBot/core/bot_service.py
@@ -46,10 +46,12 @@ class BotService:
         global_settings.cmd_history = CMDQueue(runtime_settings.cmd_hist_lim)
         log(INFO, "######### Initializing Internal Database #########", origin=L_DATABASE)
         rprint("######### Initializing Internal Database #########", origin=L_DATABASE)
-        # Back up bot database.
-        db_backup = BotServiceHelper.backup_database()
-        log(INFO, f"Created internal database backup @ {db_backup}", origin=L_DATABASE)
-        rprint(f"Created internal database backup @ {db_backup}", origin=L_DATABASE)
+        # Back up internal database.
+        if global_settings.cfg.getboolean(C_MAIN_SETTINGS, P_DB_BACKUP, fallback=False):
+            db_backup = BotServiceHelper.backup_database()
+            if db_backup:
+                log(INFO, f"Created internal database backup @ {db_backup}", origin=L_DATABASE)
+                rprint(f"Created internal database backup @ {db_backup}", origin=L_DATABASE)
         # Initialize bot database.
         global_settings.mumble_db = init_database()
         log(INFO, "######### Initialized Internal Database #########", origin=L_DATABASE)

--- a/JJMumbleBot/lib/helpers/bot_service_helper.py
+++ b/JJMumbleBot/lib/helpers/bot_service_helper.py
@@ -181,6 +181,8 @@ class BotServiceHelper:
         from os import path, makedirs
         if not path.exists(f'{dir_utils.get_main_dir()}/cfg/backups'):
             makedirs(f'{dir_utils.get_main_dir()}/cfg/backups')
+        if not path.exists(f'{dir_utils.get_main_dir()}/cfg/jjmumblebot.db'):
+            return None
         cur_time = str(datetime.now())[:19].replace(":", "_").replace(" ", "")
         src_file = f'{dir_utils.get_main_dir()}/cfg/jjmumblebot.db'
         dst_file = f'{dir_utils.get_main_dir()}/cfg/backups/jjmumblebot_{str(cur_time)}.db'

--- a/JJMumbleBot/lib/resources/strings.py
+++ b/JJMumbleBot/lib/resources/strings.py
@@ -19,6 +19,7 @@ P_DEFAULT_SU = 'DefaultSuperUser'
 P_SELF_REGISTER = "SelfRegister"
 P_USER_COMMENT = "DefaultComment"
 # Main Settings
+P_DB_BACKUP = 'EnableDatabaseBackup'
 P_AUD_STEREO = 'UseStereoOutput'
 P_CMD_TICK_RATE = 'CommandTickRate'
 P_CMD_MULTI_LIM = 'MultiCommandLimit'

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -75,6 +75,8 @@ WebTickRate = ${document.getElementById('web-interface-tick-rate-port').value}
 function get_main_settings() {
   return `
 [Main Settings]
+; Enable or disable automatic internal database backups
+EnableDatabaseBackup = ${document.getElementById('main-settings-db-backups').value}
 ; To enable stereo output for the bot, check the box. Uncheck it to disable.
 UseStereoOutput = ${document.getElementById('main-settings-stereo').value}
 ; The execution tick rate of commands in the command queue [Must be an integer/float].

--- a/docs/js/qsu_master.js
+++ b/docs/js/qsu_master.js
@@ -75,6 +75,8 @@ WebTickRate = ${document.getElementById('web-interface-tick-rate-port').value}
 function get_main_settings() {
   return `
 [Main Settings]
+; Enable or disable automatic internal database backups
+EnableDatabaseBackup = ${document.getElementById('main-settings-db-backups').value}
 ; To enable stereo output for the bot, check the box. Uncheck it to disable.
 UseStereoOutput = ${document.getElementById('main-settings-stereo').value}
 ; The execution tick rate of commands in the command queue [Must be an integer/float].

--- a/docs/pages/qsu.html
+++ b/docs/pages/qsu.html
@@ -174,6 +174,12 @@
     <div class='snippet-item'>
       <div class='snippet-text'>
         <p>Enable stereo output by checking the box, or disable by unchecking it.</p>
+        <input type="checkbox" id="main-settings-db-backups" name='main-settings-db-backups-input' class='required' checked required>
+        <label for='main-settings-db-backups'>Enable Internal Database Backups</label>
+      </div>
+      <br>
+      <div class='snippet-text'>
+        <p>Enable stereo output by checking the box, or disable by unchecking it.</p>
         <input type="checkbox" id="main-settings-stereo" name='main-settings-stereo-input' class='required' checked required>
         <label for='main-settings-stereo-input'>Use Stereo Output</label>
       </div>

--- a/docs/pages/qsu_master.html
+++ b/docs/pages/qsu_master.html
@@ -174,6 +174,12 @@
     <div class='snippet-item'>
       <div class='snippet-text'>
         <p>Enable stereo output by checking the box, or disable by unchecking it.</p>
+        <input type="checkbox" id="main-settings-db-backups" name='main-settings-db-backups-input' class='required' checked required>
+        <label for='main-settings-db-backups'>Enable Internal Database Backups</label>
+      </div>
+      <br>
+      <div class='snippet-text'>
+        <p>Enable stereo output by checking the box, or disable by unchecking it.</p>
         <input type="checkbox" id="main-settings-stereo" name='main-settings-stereo-input' class='required' checked required>
         <label for='main-settings-stereo-input'>Use Stereo Output</label>
       </div>


### PR DESCRIPTION
- Fixed issue where new users couldn't launch the bot because it was trying to backup a pre-existing internal database.
- Made automatic database backup optional in the config.ini file