### PR TITLE
New callback system

### DIFF
--- a/JJMumbleBot/core/callback_service.py
+++ b/JJMumbleBot/core/callback_service.py
@@ -1,0 +1,49 @@
+from JJMumbleBot.settings import global_settings
+from pymumble_py3.constants import PYMUMBLE_CLBK_USERCREATED, PYMUMBLE_CLBK_CONNECTED, PYMUMBLE_CLBK_SOUNDRECEIVED, \
+    PYMUMBLE_CLBK_TEXTMESSAGERECEIVED, PYMUMBLE_CLBK_DISCONNECTED, PYMUMBLE_CLBK_CHANNELUPDATED, \
+    PYMUMBLE_CLBK_CHANNELREMOVED, PYMUMBLE_CLBK_CHANNELCREATED, PYMUMBLE_CLBK_USERREMOVED, PYMUMBLE_CLBK_USERUPDATED
+
+
+class CallbackService:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def message_received(text, remote_cmd=False):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_TEXTMESSAGERECEIVED, text, remote_cmd)
+
+    @staticmethod
+    def sound_received(user, audiochunk):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_SOUNDRECEIVED, user, audiochunk)
+
+    @staticmethod
+    def connected():
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_CONNECTED)
+
+    @staticmethod
+    def disconnected():
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_DISCONNECTED)
+
+    @staticmethod
+    def channel_created(channel):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_CHANNELCREATED, channel)
+
+    @staticmethod
+    def channel_updated(channel, modified_params):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_CHANNELUPDATED, channel, modified_params)
+
+    @staticmethod
+    def channel_removed(channel):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_CHANNELREMOVED, channel)
+
+    @staticmethod
+    def user_created(user):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_USERCREATED, user)
+
+    @staticmethod
+    def user_updated(user, modified_params):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_USERUPDATED, user, modified_params)
+
+    @staticmethod
+    def user_removed(user, message):
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_USERREMOVED, user, message)

--- a/JJMumbleBot/lib/callbacks.py
+++ b/JJMumbleBot/lib/callbacks.py
@@ -1,3 +1,7 @@
+from pymumble_py3 import constants
+from JJMumbleBot.lib.utils.print_utils import dprint
+
+
 class Callbacks(dict):
     def __init__(self):
         super().__init__()
@@ -20,9 +24,38 @@ class Callbacks(dict):
 
     def callback(self, callback, *params):
         self[callback](params)
-        #if self[callback]:
+        # if self[callback]:
         #    thr = Thread(target=self[callback], args=params)
         #    thr.start()
+
+
+class CoreCallbacks(Callbacks):
+    def __init__(self):
+        super().__init__()
+        self.update({
+            constants.PYMUMBLE_CLBK_USERCREATED: [],
+            constants.PYMUMBLE_CLBK_TEXTMESSAGERECEIVED: [],
+            constants.PYMUMBLE_CLBK_SOUNDRECEIVED: [],
+            constants.PYMUMBLE_CLBK_CONNECTED: [],
+            constants.PYMUMBLE_CLBK_CHANNELCREATED: [],
+            constants.PYMUMBLE_CLBK_CHANNELREMOVED: [],
+            constants.PYMUMBLE_CLBK_CHANNELUPDATED: [],
+            constants.PYMUMBLE_CLBK_USERREMOVED: [],
+            constants.PYMUMBLE_CLBK_DISCONNECTED: []
+        })
+
+    def register_callback(self, callback, dest: list):
+        self[callback] = dest
+
+    def append_to_callback(self, callback, method):
+        self[callback].append(method)
+
+    def callback(self, callback, *params):
+        for clbk in self[callback]:
+            try:
+                clbk(params)
+            except Exception as e:
+                dprint(e)
 
 
 class CommandCallbacks(dict):

--- a/JJMumbleBot/lib/helpers/bot_service_helper.py
+++ b/JJMumbleBot/lib/helpers/bot_service_helper.py
@@ -8,7 +8,7 @@ from JJMumbleBot.lib.utils.database_utils import InsertDB, UtilityDB, DeleteDB
 from JJMumbleBot.lib.utils.plugin_utils import PluginUtilityService
 from JJMumbleBot.lib.resources.strings import *
 from JJMumbleBot.lib.utils.logging_utils import log
-from JJMumbleBot.lib.callbacks import Callbacks, CommandCallbacks
+from JJMumbleBot.lib.callbacks import Callbacks, CommandCallbacks, CoreCallbacks
 
 
 class BotServiceHelper:
@@ -32,6 +32,7 @@ class BotServiceHelper:
         global_settings.mtd_callbacks = Callbacks()
         global_settings.cmd_callbacks = CommandCallbacks()
         global_settings.plugin_callbacks = Callbacks()
+        global_settings.core_callbacks = CoreCallbacks()
 
         runtime_settings.tick_rate = float(global_settings.cfg[C_MAIN_SETTINGS][P_CMD_TICK_RATE])
         runtime_settings.cmd_hist_lim = int(global_settings.cfg[C_MAIN_SETTINGS][P_CMD_MULTI_LIM])

--- a/JJMumbleBot/lib/resources/strings.py
+++ b/JJMumbleBot/lib/resources/strings.py
@@ -104,5 +104,5 @@ P_THREAD_SINGLE = 'UseSingleThread'
 ###########################################################################
 # BOT META INFORMATION STRINGS
 META_NAME = "JJMumbleBot"
-META_VERSION = "4.0.0"
+META_VERSION = "4.1.0"
 ###########################################################################

--- a/JJMumbleBot/plugins/extensions/sound_board/metadata.ini
+++ b/JJMumbleBot/plugins/extensions/sound_board/metadata.ini
@@ -1,5 +1,5 @@
 [Plugin Information]
-PluginVersion = 4.0.0
+PluginVersion = 4.1.0
 PluginName = Sound Board
 PluginDescription = The Sound Board plugin allows users to play saved sound clips in the channel.
 PluginLanguage = EN

--- a/JJMumbleBot/plugins/extensions/sound_board/metadata.ini
+++ b/JJMumbleBot/plugins/extensions/sound_board/metadata.ini
@@ -24,6 +24,10 @@ MaxSearchResults = 5
 ; The fuzzy-search threshold between 0 to 100. Higher thresholds result in fewer, but more accurate search results. (default=80)
 ; A search threshold of 0 includes all files.
 FuzzySearchThreshold = 80
+; Play a selected audio clip when a user joins the server.
+PlayAudioClipOnUserJoin = False
+; If PlayAudioClipOnUserJoin is set to True, specify the track name (without file extension) below.
+AudioClipToPlayOnUserJoin =
 ; List commands that need the core thread to wait for completion.
 ; This may include processes that require multiple commands in succession.
 ; For example: [Youtube Plugin - !yt -> !p] process requires 2 commands in that order.

--- a/JJMumbleBot/plugins/extensions/sound_board/resources/strings.py
+++ b/JJMumbleBot/plugins/extensions/sound_board/resources/strings.py
@@ -3,3 +3,5 @@
 P_ENABLE_QUEUE = 'EnableQueue'
 P_MAX_SEARCH_RESULTS = 'MaxSearchResults'
 P_FUZZY_SEARCH_THRESHOLD = 'FuzzySearchThreshold'
+P_PLAY_AUDIO_CLIP_ON_USER_JOIN = 'PlayAudioClipOnUserJoin'
+P_AUDIO_CLIP_TO_PLAY_ON_USER_JOIN = 'AudioClipToPlayOnUserJoin'

--- a/JJMumbleBot/plugins/extensions/sound_board/sound_board.py
+++ b/JJMumbleBot/plugins/extensions/sound_board/sound_board.py
@@ -10,9 +10,10 @@ from JJMumbleBot.plugins.extensions.sound_board.utility import settings as sbu_s
 from JJMumbleBot.lib.utils.runtime_utils import get_command_token
 from JJMumbleBot.lib.utils import dir_utils
 from JJMumbleBot.lib.vlc.vlc_api import TrackType, TrackInfo
+from JJMumbleBot.lib.utils.runtime_utils import get_bot_name
 from os import path
 import random
-from datetime import datetime, timedelta
+from datetime import datetime
 from bs4 import BeautifulSoup
 
 
@@ -27,6 +28,7 @@ class Plugin(PluginBase):
         dir_utils.make_directory(f'{gs.cfg[C_MEDIA_SETTINGS][P_TEMP_MED_DIR]}/{self.plugin_name}/')
         sbu_settings.sound_board_metadata = self.metadata
         sbu_settings.plugin_name = self.plugin_name
+        self.register_callbacks()
         rprint(
             f"{self.metadata[C_PLUGIN_INFO][P_PLUGIN_NAME]} v{self.metadata[C_PLUGIN_INFO][P_PLUGIN_VERS]} Plugin Initialized.")
 
@@ -37,6 +39,39 @@ class Plugin(PluginBase):
         dir_utils.clear_directory(f'{dir_utils.get_temp_med_dir()}/{self.plugin_name}')
         dprint(f"Exiting {self.plugin_name} plugin...", origin=L_SHUTDOWN)
         log(INFO, f"Exiting {self.plugin_name} plugin...", origin=L_SHUTDOWN)
+
+    def register_callbacks(self):
+        from pymumble_py3.constants import PYMUMBLE_CLBK_USERCREATED
+        if self.metadata.getboolean(C_PLUGIN_SET, P_PLAY_AUDIO_CLIP_ON_USER_JOIN, fallback=False):
+            gs.core_callbacks.append_to_callback(PYMUMBLE_CLBK_USERCREATED, self.on_new_user_connected)
+
+    def on_new_user_connected(self, user):
+        if gs.vlc_interface.check_dni(self.plugin_name, quiet=True):
+            gs.vlc_interface.set_dni(self.plugin_name, self.metadata[C_PLUGIN_INFO][P_PLUGIN_NAME])
+        else:
+            return
+
+        to_play = self.metadata[C_PLUGIN_SET][P_AUDIO_CLIP_TO_PLAY_ON_USER_JOIN]
+        if not to_play:
+            return
+        audio_clip = sbu.find_file(to_play)
+        if not path.exists(f"{dir_utils.get_perm_med_dir()}/{self.plugin_name}/{audio_clip}"):
+            gs.vlc_interface.clear_dni()
+            return
+        track_obj = TrackInfo(
+            uri=f'{dir_utils.get_perm_med_dir()}/{self.plugin_name}/{audio_clip}',
+            name=to_play,
+            sender=get_bot_name(),
+            duration=None,
+            track_type=TrackType.FILE,
+            quiet=True
+        )
+        gs.vlc_interface.enqueue_track(
+            track_obj=track_obj,
+            to_front=False,
+            quiet=True
+        )
+        gs.vlc_interface.play(override=True)
 
     def cmd_sblist(self, data):
         internal_list = []

--- a/JJMumbleBot/settings/global_settings.py
+++ b/JJMumbleBot/settings/global_settings.py
@@ -32,9 +32,11 @@ cmd_history = None
 # Command Queue
 cmd_queue = None
 # Callbacks
+clbk_service = None
 cmd_callbacks = None
 mtd_callbacks = None
 plugin_callbacks = None
+core_callbacks = None
 # Aliases
 aliases = {}
 # Initialized Plugins.

--- a/JJMumbleBot/web/web_helper.py
+++ b/JJMumbleBot/web/web_helper.py
@@ -12,6 +12,7 @@ from threading import Thread
 from JJMumbleBot.lib import monitor_service
 from JJMumbleBot.lib.utils.web_utils import RemoteTextMessage
 from JJMumbleBot.lib.utils.runtime_utils import check_up_time, get_bot_name
+from pymumble_py3.constants import PYMUMBLE_CLBK_TEXTMESSAGERECEIVED
 import json
 from os import urandom
 
@@ -45,7 +46,7 @@ def post_message():
                                      session=global_settings.mumble_inst.users.myself['session'],
                                      message=content,
                                      actor=global_settings.mumble_inst.users.myself['session'])
-            global_settings.bot_service.message_received(text=text, remote_cmd=True)
+            global_settings.core_callbacks.callback(PYMUMBLE_CLBK_TEXTMESSAGERECEIVED, text, True)
             # print(text.message)
     return content
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A plugin-based All-In-One mumble bot solution in python 3.7+ with extensive feat
 - <b>Multi-Threaded Command Processing</b> - Commands in the queue are handled in multiple threads for faster processing.
 - <b>Reconfigurable Command Privileges</b> - The user privileges required to execute commands can be completely reconfigured.
 - <b>User Privileges System</b> - Set user privileges to server users to limit the command usage on a per-user basis.
+- <b>Extensive Callback System</b> - Create custom callbacks to mumble server events and more.
 
 ## Screenshots
 #### Audio Interface System (youtube plugin, sound board plugin, etc)


### PR DESCRIPTION
# Major Updates

## New Callback System for easy custom plugin callbacks to Mumble server events
I created a new extensive callback system that all plugins can use to directly interface with mumble server events such as receiving audio, messages, user connection/disconnection, etc.

For example, if you want a plugin to execute some code in response to a user connecting to the server, that is now possible!
**Possible uses of this system:**
 - Create a custom plugin callback to play an audio clip when a user connects to the server.
 - Create a custom plugin callback to display a message when it receives audio data from a user.
#### You can create a custom callback in any plugin to react to server events however you want!

## Sound Board Plugin (New Optional Feature)
- The sound board is now capable of playing a sound clip whenever a user connects to the server. This is configurable in  the sound board plugins metadata.ini file. **This is an optional feature.**
```
; Play a selected audio clip when a user joins the server.
PlayAudioClipOnUserJoin = False
; If PlayAudioClipOnUserJoin is set to True, specify the track name (without file extension) below.
AudioClipToPlayOnUserJoin =
```
