### PR TITLE
v4.2.1 - FFmpeg Playback and Config Fixes

### DIFF
--- a/JJMumbleBot/cfg/templates/config_template.ini
+++ b/JJMumbleBot/cfg/templates/config_template.ini
@@ -32,7 +32,7 @@ WebTickRate = 1
 FfmpegPath = ffmpeg
 ; Use Stereo Audio
 UseStereoAudio = True
-; Enable/Disable VLC Console Messages
+; Enable/Disable Audio Library Console Messages
 FfmpegRunQuiet = True
 ; The default volume when the bot starts (default=0.3)
 DefaultVolume = 0.3

--- a/JJMumbleBot/lib/audio/audio_api.py
+++ b/JJMumbleBot/lib/audio/audio_api.py
@@ -292,8 +292,8 @@ class VLCInterface:
             return
         self.callback_check('on_play')
         if global_settings.audio_inst:
-            audio_interface.stop_vlc_instance()
-        audio_interface.create_vlc_instance(self.status.get_track().uri, skipto=self.status['progress_time'])
+            audio_interface.stop_audio_instance()
+        audio_interface.create_audio_instance(self.status.get_track().uri, skipto=self.status['progress_time'])
         self.status['start_time'] = int(time())
         self.status.set_status(TrackStatus.PLAYING)
         if not track_info.quiet:
@@ -322,7 +322,7 @@ class VLCInterface:
     def pause(self):
         if self.status.is_playing():
             if global_settings.audio_inst:
-                audio_interface.stop_vlc_instance()
+                audio_interface.stop_audio_instance()
             self.calculate_progress()
             self.status['pause_time'] = int(time())
 
@@ -352,7 +352,7 @@ class VLCInterface:
 
         self.callback_check('on_skip')
         if global_settings.audio_inst:
-            audio_interface.stop_vlc_instance()
+            audio_interface.stop_audio_instance()
 
         if track_number == 0:
             global_settings.gui_service.quick_gui(
@@ -389,8 +389,8 @@ class VLCInterface:
     def seek(self, seconds: int):
         if self.status.is_playing():
             if global_settings.audio_inst:
-                audio_interface.stop_vlc_instance()
-            audio_interface.create_vlc_instance(self.status.get_track().uri, skipto=seconds)
+                audio_interface.stop_audio_instance()
+            audio_interface.create_audio_instance(self.status.get_track().uri, skipto=seconds)
 
             self.status['start_time'] = int(time())
             self.status['pause_time'] = int(time())
@@ -403,7 +403,7 @@ class VLCInterface:
 
     def stop(self):
         if global_settings.audio_inst:
-            audio_interface.stop_vlc_instance()
+            audio_interface.stop_audio_instance()
         self.callback_check('on_stop')
         self.queue = queue_handler.QueueHandler([], maxlen=int(
             global_settings.cfg[C_MEDIA_SETTINGS][P_MEDIA_QUEUE_LEN]))

--- a/JJMumbleBot/lib/audio/audio_interface.py
+++ b/JJMumbleBot/lib/audio/audio_interface.py
@@ -50,17 +50,33 @@ def create_audio_thread(ffmpeg_path: str, uri: str, skipto: int = 0, quiet: bool
         global_settings.audio_inst = None
 
     if stereo:
-        global_settings.audio_inst = sp.Popen(
-            [ffmpeg_path, "-loglevel", f'{"quiet" if quiet else "panic"}', "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f", "s16le",
-             "-ab", "192k", "-ac", "2", "-ar", "48000", "-threads", "8", "-"],
-            stdout=sp.PIPE, bufsize=1024
-        )
+        if quiet:
+            global_settings.audio_inst = sp.Popen(
+                [ffmpeg_path, "-loglevel", "quiet", "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f", "s16le",
+                 "-ab", "192k", "-ac", "2", "-ar", "48000", "-threads", "8", "-"],
+                stdout=sp.PIPE, bufsize=1024
+            )
+        else:
+            global_settings.audio_inst = sp.Popen(
+                [ffmpeg_path, "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f",
+                 "s16le",
+                 "-ab", "192k", "-ac", "2", "-ar", "48000", "-threads", "8", "-"],
+                stdout=sp.PIPE, bufsize=1024
+            )
     else:
-        global_settings.audio_inst = sp.Popen(
-            [ffmpeg_path, "-loglevel", f'{"quiet" if quiet else "panic"}', "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f", "s16le",
-             "-ab", "192k", "-ac", "2", "-ar", "24000", "-threads", "8", "-"],
-            stdout=sp.PIPE, bufsize=1024
-        )
+        if quiet:
+            global_settings.audio_inst = sp.Popen(
+                [ffmpeg_path, "-loglevel quiet", "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f", "s16le",
+                 "-ab", "192k", "-ac", "2", "-ar", "24000", "-threads", "8", "-"],
+                stdout=sp.PIPE, bufsize=1024
+            )
+        else:
+            global_settings.audio_inst = sp.Popen(
+                [ffmpeg_path, "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f",
+                 "s16le",
+                 "-ab", "192k", "-ac", "2", "-ar", "24000", "-threads", "8", "-"],
+                stdout=sp.PIPE, bufsize=1024
+            )
     rutils.unmute()
 
     while not global_settings.aud_interface.exit_flag and global_settings.audio_inst:

--- a/JJMumbleBot/lib/audio/audio_interface.py
+++ b/JJMumbleBot/lib/audio/audio_interface.py
@@ -9,9 +9,9 @@ from threading import Thread
 import subprocess as sp
 
 
-def create_vlc_instance(uri: str, skipto: int = 0):
-    global_settings.vlc_thread = Thread(
-        target=create_vlc_thread,
+def create_audio_instance(uri: str, skipto: int = 0):
+    global_settings.audio_thread = Thread(
+        target=create_audio_thread,
         args=(
             global_settings.cfg[C_MEDIA_SETTINGS][P_MEDIA_FFMPEG_PATH],
             uri,
@@ -21,20 +21,20 @@ def create_vlc_instance(uri: str, skipto: int = 0):
         ),
         daemon=True
     )
-    global_settings.vlc_thread.start()
+    global_settings.audio_thread.start()
 
 
-def stop_vlc_instance():
+def stop_audio_instance():
     if global_settings.audio_inst:
         global_settings.audio_inst.terminate()
         global_settings.audio_inst.kill()
         global_settings.audio_inst = None
-    if global_settings.vlc_thread:
-        global_settings.vlc_thread.join()
-        global_settings.vlc_thread = None
+    if global_settings.audio_thread:
+        global_settings.audio_thread.join()
+        global_settings.audio_thread = None
 
 
-def create_vlc_thread(ffmpeg_path: str, uri: str, skipto: int = 0, quiet: bool = True, stereo: bool = True):
+def create_audio_thread(ffmpeg_path: str, uri: str, skipto: int = 0, quiet: bool = True, stereo: bool = True):
     if uri == '':
         return
 
@@ -72,7 +72,7 @@ def create_vlc_thread(ffmpeg_path: str, uri: str, skipto: int = 0, quiet: bool =
                 global_settings.mumble_inst.sound_output.add_sound(audioop.mul(raw_music, 2, global_settings.aud_interface.status.get_volume()))
             else:
                 if global_settings.aud_interface.next_track():
-                    create_vlc_thread(ffmpeg_path=ffmpeg_path, uri=global_settings.aud_interface.status.get_track().uri, skipto=0, quiet=quiet, stereo=stereo)
+                    create_audio_thread(ffmpeg_path=ffmpeg_path, uri=global_settings.aud_interface.status.get_track().uri, skipto=0, quiet=quiet, stereo=stereo)
                 else:
                     global_settings.aud_interface.reset()
                 return

--- a/JJMumbleBot/lib/audio/audio_interface.py
+++ b/JJMumbleBot/lib/audio/audio_interface.py
@@ -52,14 +52,17 @@ def create_audio_thread(ffmpeg_path: str, uri: str, skipto: int = 0, quiet: bool
     if stereo:
         if quiet:
             global_settings.audio_inst = sp.Popen(
-                [ffmpeg_path, "-loglevel", "quiet", "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f", "s16le",
+                [ffmpeg_path, "-loglevel", "quiet",
+                 "-reconnect", "1", "-reconnect_at_eof", "1", "-reconnect_streamed", "1", "-reconnect_delay_max", "2",
+                 "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f", "s16le",
                  "-ab", "192k", "-ac", "2", "-ar", "48000", "-threads", "8", "-"],
                 stdout=sp.PIPE, bufsize=1024
             )
         else:
             global_settings.audio_inst = sp.Popen(
-                [ffmpeg_path, "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f",
-                 "s16le",
+                [ffmpeg_path,
+                 "-reconnect", "1", "-reconnect_at_eof", "1", "-reconnect_streamed", "1", "-reconnect_delay_max", "2",
+                 "-i", uri, "-ss", f"{skipto}", "-acodec", "pcm_s16le", "-f", "s16le",
                  "-ab", "192k", "-ac", "2", "-ar", "48000", "-threads", "8", "-"],
                 stdout=sp.PIPE, bufsize=1024
             )

--- a/JJMumbleBot/settings/global_settings.py
+++ b/JJMumbleBot/settings/global_settings.py
@@ -22,7 +22,7 @@ quiet_mode: bool = False
 verbose_mode: bool = False
 # Audio Thread Instance
 audio_inst = None
-vlc_thread = None
+audio_thread = None
 audio_dni = None
 aud_interface = None
 # Bot State


### PR DESCRIPTION
### FFmpeg Playback Fix
- Fixed FFmpeg playback issue where the youtube video would stop playing 2/3rds of the way through because the URL expires. FFmpeg now auto-regenerates the URL when this error occurs.

### FFmpeg Config Fix
- Fixed 'FfmpegRunQuiet' config parameter.

### Other Updates
- Removed additional deprecated references to VLC.