### PR TITLE
Logging Fixes

### DIFF
--- a/JJMumbleBot/templates/config_template.ini
+++ b/JJMumbleBot/templates/config_template.ini
@@ -59,7 +59,7 @@ PermanentMediaDirectory =
 
 [Logging]
 ; Enable/Disable logging
-EnableLogging = True
+EnableLogging = False
 ; Maximum log limit
 MaxLogs = 20
 ; Maximum size per log (in Bytes)

--- a/JJMumbleBot/tests/dummy_config.ini
+++ b/JJMumbleBot/tests/dummy_config.ini
@@ -53,7 +53,7 @@ PermanentMediaDirectory = PERM_MEDIA_DIR_PATH
 
 [Logging]
 ; Enable Logging Flag
-EnableLogging = true
+EnableLogging = False
 ; Maximum Log Limit
 MaxLogs = 20
 ; Maximum size per log (in Bytes)

--- a/JJMumbleBot/tests/dummy_config.ini
+++ b/JJMumbleBot/tests/dummy_config.ini
@@ -56,6 +56,8 @@ PermanentMediaDirectory = PERM_MEDIA_DIR_PATH
 EnableLogging = true
 ; Maximum Log Limit
 MaxLogs = 20
+; Maximum size per log (in Bytes)
+MaxLogSize = 150000
 ; Enable/Disable channel message logging (Enabling it will hide message logs to: Message Received: [User -> #####])
 HideMessageLogging = True
 ; Path to the logs directory. All bot logs will be stored in this directory.

--- a/JJMumbleBot/tests/test_cfg.py
+++ b/JJMumbleBot/tests/test_cfg.py
@@ -128,7 +128,7 @@ class Test_Cfg:
     # Logging Config Tests
     def test_enable_logging(self):
         enable_logging = self.cfg.getboolean(C_LOGGING, P_LOG_ENABLE)
-        assert enable_logging is True
+        assert enable_logging is False
 
     def test_max_log_limit(self):
         max_log_limit = int(self.cfg[C_LOGGING][P_LOG_MAX])

--- a/__main__.py
+++ b/__main__.py
@@ -242,13 +242,13 @@ if __name__ == "__main__":
     if args.use_logging:
         global_settings.cfg[C_LOGGING][P_LOG_ENABLE] = args.use_logging
     if args.max_logs:
-        global_settings.cfg[C_LOGGING][P_LOG_ENABLE] = args.max_logs
+        global_settings.cfg[C_LOGGING][P_LOG_MAX] = args.max_logs
     if args.max_log_size:
-        global_settings.cfg[C_LOGGING][P_LOG_ENABLE] = args.max_log_size
+        global_settings.cfg[C_LOGGING][P_LOG_SIZE_MAX] = args.max_log_size
     if args.hide_log_messages:
-        global_settings.cfg[C_LOGGING][P_LOG_ENABLE] = args.hide_log_messages
+        global_settings.cfg[C_LOGGING][P_LOG_MESSAGES] = args.hide_log_messages
     if args.log_directory:
-        global_settings.cfg[C_LOGGING][P_LOG_ENABLE] = args.log_directory
+        global_settings.cfg[C_LOGGING][P_LOG_DIR] = args.log_directory
     # Overwrite main settings if the launch parameter is provided.
     if args.use_database_backups:
         global_settings.cfg[C_MAIN_SETTINGS][P_DB_BACKUP] = args.use_database_backups


### PR DESCRIPTION
- Fixed launch parameters for logging functionality.
- Disabled logging by default for new users, this can be enabled in the `config.ini` file or with the `-uselogging` launch parameter.
- Updated and fixed unit tests.