### PR TITLE
v4.3.2 Update - Sound Board Web Interface & Bug Fixes

### DIFF
--- a/JJMumbleBot/plugins/extensions/media/utility/youtube_search.py
+++ b/JJMumbleBot/plugins/extensions/media/utility/youtube_search.py
@@ -42,7 +42,7 @@ class YoutubeSearch:
         BASE_URL = "https://youtube.com"
         url = f"{BASE_URL}/results?search_query={encoded_search}"
         response = requests.get(url).text
-        while 'window["ytInitialData"]' not in response:
+        while "ytInitialData" not in response:
             response = requests.get(url).text
         results = self.parse_html(response)
         if self.max_results is not None and len(results) > self.max_results:
@@ -51,27 +51,19 @@ class YoutubeSearch:
 
     def parse_html(self, response):
         results = []
-        start = (
-            response.index('window["ytInitialData"]')
-            + len('window["ytInitialData"]')
-            + 3
-        )
+        start = (response.index("ytInitialData") + len("ytInitialData") + 3)
         end = response.index("};", start) + 1
         json_str = response[start:end]
         data = json.loads(json_str)
 
-        videos = data["contents"]["twoColumnSearchResultsRenderer"]["primaryContents"][
-            "sectionListRenderer"
-        ]["contents"][0]["itemSectionRenderer"]["contents"]
+        videos = data["contents"]["twoColumnSearchResultsRenderer"]["primaryContents"]["sectionListRenderer"]["contents"][0]["itemSectionRenderer"]["contents"]
 
         for video in videos:
             res = {}
             if "videoRenderer" in video.keys():
                 video_data = video["videoRenderer"]
                 res["title"] = video_data["title"]["runs"][0]["text"]
-                res["href"] = video_data["navigationEndpoint"]["commandMetadata"][
-                    "webCommandMetadata"
-                ]["url"]
+                res["href"] = video_data["navigationEndpoint"]["commandMetadata"]["webCommandMetadata"]["url"]
                 results.append(res)
         return results
 

--- a/JJMumbleBot/plugins/extensions/server_tools/server_tools.py
+++ b/JJMumbleBot/plugins/extensions/server_tools/server_tools.py
@@ -52,6 +52,10 @@ class Plugin(PluginBase):
         if not self.metadata.getboolean(C_PLUGIN_SET, P_PLAY_AUDIO_CLIP_ON_USER_JOIN, fallback=False):
             return
 
+        # Return if the user that connected is the bot (self-detection).
+        if user[0]['name'] == self.metadata[C_CONNECTION_SETTINGS][P_USER_ID]:
+            return
+
         if gs.aud_interface.check_dni(self.plugin_name, quiet=True):
             gs.aud_interface.set_dni(self.plugin_name, self.metadata[C_PLUGIN_INFO][P_PLUGIN_NAME])
         else:

--- a/JJMumbleBot/plugins/extensions/sound_board/metadata.ini
+++ b/JJMumbleBot/plugins/extensions/sound_board/metadata.ini
@@ -18,7 +18,7 @@ PluginCommands: [
 
 [Plugin Settings]
 ; This allows the sound board plugin to queue sound clips instead of playing them directly. (default=False)
-EnableQueue = False
+EnableQueue = True
 ; The maximum number of search results to be shown from the !sbsearch command. (default=5)
 MaxSearchResults = 5
 ; The fuzzy-search threshold between 0 to 100. Higher thresholds result in fewer, but more accurate search results. (default=80)

--- a/JJMumbleBot/plugins/extensions/sound_board/utility/sound_board_utility.py
+++ b/JJMumbleBot/plugins/extensions/sound_board/utility/sound_board_utility.py
@@ -13,7 +13,8 @@ def prepare_sb_list():
     file_counter = 0
     gather_list = []
     for file_item in os.listdir(f"{dir_utils.get_perm_med_dir()}/{settings.plugin_name}/"):
-        gather_list.append(f"{file_item}")
+        file_name = file_item.rsplit(".", 1)[0]
+        gather_list.append(f"{file_name}")
         file_counter += 1
     gather_list.sort(key=str.lower)
     return gather_list

--- a/JJMumbleBot/web/static/js/index.js
+++ b/JJMumbleBot/web/static/js/index.js
@@ -45,7 +45,7 @@ function download_report() {
     download(JSON.stringify(data_storage), 'bot_report.json', 'text/plain')
 }
 
-function skipto_command (button_id) {
+function skipto_command(button_id) {
     $.ajax({
         type: 'POST',
         url: '/skipto',
@@ -54,7 +54,7 @@ function skipto_command (button_id) {
     })
     setAudioQueueInformation();
 }
-function removetrack_command (button_id) {
+function removetrack_command(button_id) {
     $.ajax({
         type: 'POST',
         url: '/removetrack',
@@ -64,3 +64,11 @@ function removetrack_command (button_id) {
     setAudioQueueInformation();
 }
 
+function playclip_command(clipname) {
+    $.ajax({
+        type: 'POST',
+        url: '/soundboard-play',
+        contentType: "application/json",
+        data: JSON.stringify({'data': clipname})
+    })
+}

--- a/JJMumbleBot/web/templates/index.html
+++ b/JJMumbleBot/web/templates/index.html
@@ -20,6 +20,7 @@
         <div class="nav nav-tabs" id="nav-tab" role="tablist">
             <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Main</a>
             <a class="nav-link" id="audio-tab" data-toggle="tab" href="#audio" role="tab" aria-controls="audio" aria-selected="false">Audio Interface</a>
+            <a class="nav-link" id="soundboard-tab" data-toggle="tab" href="#soundboard" role="tab" aria-controls="soundboard" aria-selected="false">Sound Board</a>
         </div>
     </nav>
     <br>
@@ -86,6 +87,17 @@
                 </div>
             </div>
         </div>
+
+        {% if "sound_board" in plugins %}
+        <div class="tab-pane fade" id="soundboard" role="tabpanel" aria-labelledby="soundboard-tab">
+            <div class="container border border-dark rounded">
+                <button class="refresh_form btn btn-outline-secondary btn-sm" id="soundboard-refresh">Refresh</button>
+            </div>
+            <div class="container border border-dark rounded" id="soundboard-buttons">
+
+            </div>
+        </div>
+        {% endif %}
 
         <div class="tab-pane fade" id="audio" role="tabpanel" aria-labelledby="audio-tab">
             <div class="container border border-dark rounded">
@@ -159,6 +171,31 @@
 
           setAudioQueueInformation();
           setChannelInformation();
+        }
+
+        function setSoundBoardInformation() {
+            if (!("soundboard_clips" in data_storage)) return;
+            var soundboard_buttons = document.getElementById("soundboard-buttons");
+            soundboard_buttons.innerHTML = "";
+
+            var clip_count = 0;
+            for (var clip of Object.keys(data_storage["soundboard_clips"])) {
+                var clip_name = data_storage["soundboard_clips"][clip];
+                var clip_item = document.createElement("button");
+                clip_item.setAttribute("id", `${clip_count}-${clip_name}`);
+                clip_item.setAttribute("onclick", `playclip_command(\"${clip_name}\")`);
+                clip_item.setAttribute("style", "padding: 5px");
+                clip_item.innerHTML = clip_name;
+                clip_item.style.padding = "5px";
+                clip_item.classList.add("soundboard_clip_btn");
+                clip_item.classList.add("btn");
+                clip_item.classList.add("btn-outline");
+                clip_item.classList.add("btn-outline-info");
+                clip_item.classList.add("btn-sm");
+                clip_item.classList.add("no-transition");
+                soundboard_buttons.appendChild(clip_item);
+                clip_count++;
+            }
         }
 
         function setAudioQueueInformation() {
@@ -240,6 +277,13 @@
             fetch('http://{{ server_ip }}:{{ server_port }}/system')
                 .then(response => response.json())
                 .then(json => $.extend(data_storage, json));
+            fetch('http://{{ server_ip }}:{{ server_port }}/soundboardclips')
+                .then(response => response.json())
+                .then(json => {
+                    $.extend(data_storage, json);
+                    setSoundBoardInformation();
+                 });
+
 
             $('form').on('submit', function(event) {
                 $.ajax({
@@ -338,6 +382,7 @@
 
             $('.refresh_form').click(function(event) {
             setAudioQueueInformation();
+            setSoundBoardInformation();
             });
         });
     </script>

--- a/JJMumbleBot/web/templates/index.html
+++ b/JJMumbleBot/web/templates/index.html
@@ -92,6 +92,7 @@
         <div class="tab-pane fade" id="soundboard" role="tabpanel" aria-labelledby="soundboard-tab">
             <div class="container border border-dark rounded">
                 <button class="refresh_form btn btn-outline-secondary btn-sm" id="soundboard-refresh">Refresh</button>
+                <button type="submit" class="stop_form btn btn-outline-danger btn-sm" id="soundboard-control-stop">Stop</button>
             </div>
             <div class="container border border-dark rounded" id="soundboard-buttons">
 

--- a/JJMumbleBot/web/templates/index.html
+++ b/JJMumbleBot/web/templates/index.html
@@ -179,14 +179,28 @@
             soundboard_buttons.innerHTML = "";
 
             var clip_count = 0;
+
+            var lastClipSection = 'Misc';
+            var sectionSeparator = document.createElement("h3");
+            sectionSeparator.innerHTML = lastClipSection;
+            soundboard_buttons.appendChild(sectionSeparator);
+
             for (var clip of Object.keys(data_storage["soundboard_clips"])) {
                 var clip_name = data_storage["soundboard_clips"][clip];
+                if (clip_name.charAt(0).toLowerCase() != clip_name.charAt(0).toUpperCase()) {
+                    if (clip_name.toLowerCase().charAt(0) !== lastClipSection.toLowerCase().charAt(0)) {
+                        lastClipSection = String.fromCharCode(clip_name.charCodeAt(0)).charAt(0);
+                        sectionSeparator = document.createElement("h3");
+                        sectionSeparator.innerHTML = lastClipSection.toUpperCase();
+                        soundboard_buttons.appendChild(sectionSeparator);
+                    }
+                }
+
                 var clip_item = document.createElement("button");
                 clip_item.setAttribute("id", `${clip_count}-${clip_name}`);
                 clip_item.setAttribute("onclick", `playclip_command(\"${clip_name}\")`);
-                clip_item.setAttribute("style", "padding: 5px");
                 clip_item.innerHTML = clip_name;
-                clip_item.style.padding = "5px";
+                clip_item.style.padding = "20px";
                 clip_item.classList.add("soundboard_clip_btn");
                 clip_item.classList.add("btn");
                 clip_item.classList.add("btn-outline");

--- a/JJMumbleBot/web/web_helper.py
+++ b/JJMumbleBot/web/web_helper.py
@@ -140,6 +140,27 @@ def get_system_info():
     return json.dumps(monitor_service.get_system_info())
 
 
+@web_app.route("/soundboardclips", methods=['GET'])
+def get_soundboard_data():
+    if "sound_board" in list(global_settings.bot_plugins):
+        import JJMumbleBot.plugins.extensions.sound_board.utility.sound_board_utility as sbu
+        clips_list = sbu.prepare_sb_list()
+        return json.dumps({"soundboard_clips": clips_list})
+    return ''
+
+
+@web_app.route("/soundboard-play", methods=['POST'])
+def play_soundboard_clip():
+    content = request.json['data']
+    if len(content) > 0:
+        text = RemoteTextMessage(channel_id=global_settings.mumble_inst.users.myself['channel_id'],
+                                     session=global_settings.mumble_inst.users.myself['session'],
+                                     message=f"{global_settings.cfg[C_MAIN_SETTINGS][P_CMD_TOKEN]}sbquietnow {content}",
+                                     actor=global_settings.mumble_inst.users.myself['session'])
+        global_settings.core_callbacks.callback(PYMUMBLE_CLBK_TEXTMESSAGERECEIVED, text, True)
+    return content
+
+
 @web_app.route("/", methods=['GET', 'POST'])
 def main():
     return render_template(


### PR DESCRIPTION
###  Sound Board and Web Interface Updates
- The web interface now has a new Sound Board tab which displays all the sound board clips available and can play these clips directly from the web interface.
- Sound board clips can now be queued by default (this can be disabled in the soundboard  plugin's metadata.ini file)
- Changed  sound board clip gathering to exclude file extensions. This means that commands that display sound clips will no longer display the file extension of the audio clip.

### Bug  Fixes
- Fixed  <code>ytsearch</code> command.
- Fixed  occassional issue where the bot audio thread got stuck on connecting to the server.