### PR TITLE
Run server on docker container without need of docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM docker.io/python:3-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -17,9 +17,11 @@ EXPOSE 7000
 WORKDIR /app
 # Add all the requirements.txt files from the requirements folder and install them.
 ADD ./requirements/ /app
-RUN pip install -r requirements.txt --no-warn-script-location
-RUN pip install -r web_server.txt --no-warn-script-location
+RUN pip install -r requirements.txt -r web_server.txt --no-warn-script-location
 COPY . /app
 
 # Cleanup database files
 RUN find /app -name "*.db" -exec rm -rf {} \;
+
+CMD ["python", "/app"]
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
   bot:
     image: jasonjerome/jjmumblebot
+    # Expose all ports to localhost
     network_mode: "host"
     volumes:
       - ./JJMumbleBot/cfg:/app/JJMumbleBot/cfg

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,12 @@
-version: '3'
+version: '3.8'
 services:
   bot:
-    build: .
-    # Expose all ports to localhost
+    image: jasonjerome/jjmumblebot
     network_mode: "host"
     volumes:
       - ./JJMumbleBot/cfg:/app/JJMumbleBot/cfg
     environment:
-      - MUMBLE_IP=test
+      - MUMBLE_IP=localhost
       - MUMBLE_PORT=64738
       - MUMBLE_PASSWORD=
-    entrypoint: python /app
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   bot:
-    image: jasonjerome/jjmumblebot
+    build: .
     # Expose all ports to localhost
     network_mode: "host"
     volumes:


### PR DESCRIPTION
With these changes, the container itself will launch the application, instead of relying on the docker-compose file to do this. I also added **docker.io/** before the FROM statement. This way the container can more easily be built by other container programs (like podman).